### PR TITLE
fix: reformatted code so clippy and rustfmt checks pass

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -40,7 +40,7 @@ jobs:
         run: cargo test
 
   fmt:
-    name: Lint with rmstfmt
+    name: Lint with rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/src/components/postgress.rs
+++ b/src/components/postgress.rs
@@ -1,5 +1,6 @@
-use deadpool_postgres::{Config, Pool, PoolConfig, Runtime};
 use std::env;
+
+use deadpool_postgres::{Config, Pool, PoolConfig, Runtime};
 use tokio_postgres::NoTls;
 
 pub fn configure() -> Pool {
@@ -24,5 +25,5 @@ pub fn configure() -> Pool {
         .unwrap();
 
     cfg.pool = PoolConfig::new(pool_size).into();
-    return cfg.create_pool(Some(Runtime::Tokio1), NoTls).unwrap();
+    cfg.create_pool(Some(Runtime::Tokio1), NoTls).unwrap()
 }

--- a/src/components/redis.rs
+++ b/src/components/redis.rs
@@ -1,8 +1,9 @@
+use std::env;
+use std::time::Duration;
+
 use deadpool_redis::{
     ConnectionAddr, ConnectionInfo, Pool, PoolConfig, RedisConnectionInfo, Runtime, Timeouts,
 };
-use std::env;
-use std::time::Duration;
 
 pub fn configure() -> Pool {
     let mut cfg = deadpool_redis::Config::default();
@@ -25,5 +26,5 @@ pub fn configure() -> Pool {
         },
     });
 
-    return cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+    cfg.create_pool(Some(Runtime::Tokio1)).unwrap()
 }

--- a/src/http_in.rs
+++ b/src/http_in.rs
@@ -42,23 +42,24 @@ async fn register(
     match diplomat::postgres::task::insert(&task, data.postgress_pool.to_owned()).await {
         Err(err) => {
             println!("error: {}", err.as_str());
-            return HttpResponse::BadRequest().body(format!(
-                "It wasn't possible to insert on the persistent storage"
-            ));
+            return HttpResponse::BadRequest()
+                .body("It wasn't possible to insert on the persistent storage".to_string());
         }
         Ok(r) => r,
     };
 
-    return match diplomat::redis::task::insert(
+    match diplomat::redis::task::insert(
         timestamp_next_execution_time,
         &task,
         data.redis_pool.to_owned(),
     )
     .await
     {
-        Err(_) => HttpResponse::BadRequest().body(format!("It wasn't possible to insert on cache")),
+        Err(_) => {
+            HttpResponse::BadRequest().body("It wasn't possible to insert on cache".to_string())
+        }
         Ok(_) => HttpResponse::Ok().body("Ok"),
-    };
+    }
 }
 
 #[post("/echo")]

--- a/src/logic/task.rs
+++ b/src/logic/task.rs
@@ -2,18 +2,16 @@ use crate::schemas::models::task;
 
 pub fn is_minimum_recurrence_time_valid(task: &task::Task) -> bool {
     let minimum_recurrence_time = worst_case_retry(&task.retry_policy);
-    return match minimum_recurrence_time {
-        Some(min_rec_time) => &task.execution_timeout > &min_rec_time,
+    match minimum_recurrence_time {
+        Some(min_rec_time) => task.execution_timeout > min_rec_time,
         None => false,
-    };
+    }
 }
 
 pub fn worst_case_retry(retry_policy: &task::RetryPolicy) -> Option<i32> {
     let exponential_backoff: i32 = 2;
 
-    let minimum_recurrence_time = (0..=(retry_policy.times - 1) as u32)
+    (0..=(retry_policy.times - 1) as u32)
         .map(|x| retry_policy.interval * exponential_backoff.pow(x) + retry_policy.jitter_limit)
-        .reduce(|acc, x| acc + x);
-
-    return minimum_recurrence_time;
+        .reduce(|acc, x| acc + x)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 use actix_web::{web, App, HttpServer};
+
+use http_in::*;
+
 mod adapters;
 mod components;
 mod diplomat;
 mod http_in;
 mod logic;
 mod schemas;
-use http_in::*;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1,4 +1,5 @@
 pub mod components;
+
 pub mod models {
     pub mod task;
 }
@@ -11,6 +12,7 @@ pub mod wire_out {
     pub mod db {
         pub mod task;
     }
+
     pub mod redis {
         pub mod task;
     }

--- a/src/schemas/wire_out/db/task.rs
+++ b/src/schemas/wire_out/db/task.rs
@@ -1,10 +1,10 @@
-pub struct Task {
-    pub id: i64,
-    pub name: String,
-    pub schedule: String,
-    pub url: String,
-    pub execution_timeout: i32,
-    pub retry_times: i32,
-    pub retry_interval: i32,
-    pub retry_jitter_limit: i32,
-}
+// pub struct Task {
+//     pub id: i64,
+//     pub name: String,
+//     pub schedule: String,
+//     pub url: String,
+//     pub execution_timeout: i32,
+//     pub retry_times: i32,
+//     pub retry_interval: i32,
+//     pub retry_jitter_limit: i32,
+// }

--- a/src/schemas/wire_out/redis/task.rs
+++ b/src/schemas/wire_out/redis/task.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
-
 pub struct Task {
     pub n: String,
     pub s: String,
@@ -9,6 +8,7 @@ pub struct Task {
     pub rp: RetryPolicy,
     pub et: i32,
 }
+
 #[derive(Deserialize, Serialize)]
 pub struct RetryPolicy {
     pub t: i32,


### PR DESCRIPTION
- You'll see that after the changes I've made, both clippy and rustfmt are now passing whereas [clippy was failing before](https://github.com/gumberss/Schedulinator/actions/runs/6374348830/job/17298892153)
- [rustfmt](https://github.com/rust-lang/rustfmt) focuses on the code being correct, e.g. not having a double whitespace and being valid syntax
- [clippy](https://github.com/rust-lang/rust-clippy) tries to catch common mistakes where, although your code (usually) does what you want, you could have done something in a more efficient or idiomatic manner
- you can integrate both tools into your IDE to check and automatically correct you as you code, as well as using them in CI